### PR TITLE
Add run_tiny and run_medium targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,13 @@ set(CMAKE_CXX_FLAGS "-Ofast")
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_executable(pace $<TARGET_OBJECTS:common> "${PROJECT_SOURCE_DIR}/src/main.cpp")
 target_link_libraries(pace "${PROJECT_SOURCE_DIR}/lp_solve_5.5/lpsolve55/bin/ux64/liblpsolve55.a" dl)
+
+add_custom_target(run_tiny
+  COMMAND sh run_set.sh tiny-set
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)
+
+add_custom_target(run_medium
+  COMMAND sh run_set.sh medium-set
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)

--- a/run_case.sh
+++ b/run_case.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <set> <case>"
+    exit 1
+fi
+
+mkdir -p /tmp/pace
+
+# Run test case and compare output with solution
+./build/pace < "./test/$1/instances/$2.gr" > "/tmp/pace/$2.out"
+echo "diff for case $1/$2: "
+diff -Z "./test/$1/solutions/$2.sol" "/tmp/pace/$2.out"
+rm "/tmp/pace/$2.out"
+
+rmdir /tmp/pace

--- a/run_set.sh
+++ b/run_set.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <set>"
+    exit 1
+fi
+
+# Run each instance from the given set
+for file in ./test/$1/instances/*; do
+
+    # Bash shenanigans for getting the file name without extensions
+    file=${file##*/}
+    file=${file%.*}
+
+    sh run_case.sh "$1" "$file"
+    echo
+done


### PR DESCRIPTION
Currently runs the test cases from each set and the diffs it with sol file. Must eventually be changed to running the verifier against each output.