### PR TITLE
Add clang-format section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Simply run:
 cmake -B build && make -C build
 ```
 
+## Adding commits
+
+All commits to `main` should be done through pull requests. The formatting rules for the source code are specified in `.clang-format` and code is automatically formatted on each new commit to an open PR. You can either:
+
+1. Run `clang-format` locally
+2. Rely on the automatic commits by `Bananlyzer` when you open and update PRs. Remember to always [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing "Documentation for Git Rebasing") your local PR branch afterwards to avoid merge conflicts.
+
+Additional information can be checked at [style.md](style.md) .
+
 ## Execution
 
 ### Default execution

--- a/style.md
+++ b/style.md
@@ -1,0 +1,15 @@
+# Style Guide
+
+## Formatting
+
+Formatting is automatically handled by GitHub actions on open Pull Requests. If any code must be formatted, an automatic commit with the user `Bananalyzer` is added to make these changes. If you want to format your source code locally, install `clang` and run the following command on the project's root.
+
+``` shell
+clang-format -i src/*
+```
+
+## Naming Conventions
+
+* Global variables and classes should be named in CamelCase. 
+* Local variables should be named in snake_case. 
+* Class members names should be prefixed with `m_`.


### PR DESCRIPTION
* Explain how to use `clang-format`
* Explain how **Bananalyzer** works.
* Explain both options for development workflow:
  1. Formatting locally with `clang-format`
  2. Relying on **Bananalyzer**, in that case the code after formatting must be tested. 