### PR TITLE
Create .sh script to parallelize and evaluate test cases

### DIFF
--- a/eval_case.sh
+++ b/eval_case.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
 if [ $# -lt 4 ]; then
-    echo "Usage: $0 <set> <case> <tl> <ml> <args>"
+    echo "Usage: $0 <file> <tl> <ml> <args>"
     exit 1
 fi
 
 ARGS=$*
 
-# Run test case, the solution is expected to be verified inside the solver itself
-echo "running for case $1/$2:"
-ulimit -v "$4"
-timeout -s "SIGTERM" "$3" ./build/pace --verify="./test/$1/solutions/$2.sol" < "./test/$1/instances/$2.gr" > /dev/null 2>/dev/null
+ulimit -v "$3"
+timeout -s "SIGTERM" "$2" ./build/pace "$ARGS" < "$1" >/dev/null 2>/dev/null
 exit_code=$?
 
 if [ $exit_code -eq 139 ]; then

--- a/eval_set.sh
+++ b/eval_set.sh
@@ -1,26 +1,47 @@
 #!/bin/bash
 
-if [ $# -lt 3 ]; then
-    echo "Usage: $0 <set> <tl> <ml> <args>"
+if [ ! $# -eq 1 ]; then
+    echo "Usage: $0 <file>"
     exit 1
 fi
 
-out=/tmp/"$1".csv
+if [ ! "$(wc -l < $1)" -eq 5 ]; then
+    echo "$1 does not have 5 lines!"
+    exit 1
+fi
+
+path=$(sed -n '1 p' "$1")
+tl=$(sed -n '2 p' "$1")
+ml=$(sed -n '3 p' "$1")
+jobs=$(sed -n '4 p' "$1")
+args=$(sed -n '5 p' "$1")
+
+out_name=${1##*/}
+out_name=${out_name%.*}
+
+out="$out_name".csv
 
 if [ -f "$out" ]; then
     rm -f "$out"
 fi
 
-echo "# SET:$1 TL:$2 ML:$3" >> "$out"
+echo "# SET:$path TL:$tl ML:$ml ARGS:$args" >> "$out"
 echo "CASE, STATUS, TIME(s), MEMORY(KiB)" >> "$out"
 
 # Run each instance from the given set
-for file in ./test/"$1"/instances/*; do
+for file in "$path"/*.gr; do
+    cnt=$(ps | wc -l)
+
+    while [[ "$cnt" -gt  "$jobs" ]]; do
+        echo "Currently there are $cnt jobs running, waiting..."
+        sleep "10s"
+        cnt=$(ps | wc -l)
+    done
 
     # Bash shenanigans for getting the file name without extensions
-    file=${file##*/}
-    file=${file%.*}
+    name_file=${file##*/}
+    name_file=${name_file%.*}
 
-    echo "$file," "$(sh eval_case.sh "$1" "$file" "$2" "$3" | tail -n 1)," \
-         "$(/usr/bin/time -f'%e\n%M' sh eval_case.sh "$1" "$file" "$2" "$3" 2>&1 | sed -n '3,4p' | tr '\n' ',')" >> "$out" &
+    echo "$name_file," "$(sh eval_case.sh "$file" "$tl" "$ml" "$args" | tail -n 1)," \
+         "$(/usr/bin/time -f'%e\n%M' sh eval_case.sh "$file" "$tl" "$ml" "$args" 2>&1 | sed -n '2,3 p' | tr '\n' ',')" >> "$out" &
 done


### PR DESCRIPTION
The script should run all the test cases in a directory and create a .csv file with the results.

The script should limit each test case to a 30' runtime and 8GB memory usage.

The .csv file columns should be the test case, the result (TLE, MLE or Solved), the time it took to run and the memory usage.

The script should receive as parameters the number of processes to be created, the folder in which the test cases are and the path to the output file.

We need this in order to evaluate the improvements on the solver over time.