### PR TITLE
Crossing Matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,9 @@ set(SRC_FILES
   "${PROJECT_SOURCE_DIR}/src/subdivided_wheel_recognizer.cpp"
   "${PROJECT_SOURCE_DIR}/src/starforest_recognizer.cpp"
   "${PROJECT_SOURCE_DIR}/src/outerplanar_recognizer.cpp"
-  "${PROJECT_SOURCE_DIR}/src/lobster_recognizer.cpp")
+  "${PROJECT_SOURCE_DIR}/src/lobster_recognizer.cpp"
+  "${PROJECT_SOURCE_DIR}/src/interval_system.cpp"
+  "${PROJECT_SOURCE_DIR}/src/crossing_matrix.cpp")
 
 ## Objetos comuns a todos os targets
 add_library(common OBJECT ${SRC_FILES})

--- a/src/bipartite_graph.cpp
+++ b/src/bipartite_graph.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Alan Prado
+ *   Alan Prado, Heitor Leite
  *
  * This file is part of Banana, a one-sided crossing minimization solver.
  *

--- a/src/bipartite_graph.cpp
+++ b/src/bipartite_graph.cpp
@@ -82,15 +82,9 @@ std::vector<std::vector<int>> BipartiteGraph::buildCrossingMatrix() const
   return crossing_matrix;
 }
 
-std::vector<int> BipartiteGraph::getA() const
-{
-  return m_partA;
-}
+std::vector<int> BipartiteGraph::getA() const { return m_partA; }
 
-std::vector<int> BipartiteGraph::getB() const
-{
-  return m_partB;
-}
+std::vector<int> BipartiteGraph::getB() const { return m_partB; }
 
 } // namespace graph
 } // namespace banana

--- a/src/bipartite_graph.cpp
+++ b/src/bipartite_graph.cpp
@@ -82,5 +82,15 @@ std::vector<std::vector<int>> BipartiteGraph::buildCrossingMatrix() const
   return crossing_matrix;
 }
 
+std::vector<int> BipartiteGraph::getA() const
+{
+  return m_partA;
+}
+
+std::vector<int> BipartiteGraph::getB() const
+{
+  return m_partB;
+}
+
 } // namespace graph
 } // namespace banana

--- a/src/bipartite_graph.h
+++ b/src/bipartite_graph.h
@@ -17,6 +17,7 @@
 #define __PACE2024__BIPARTITE_GRAPH_H
 
 #include "lgraph.h"
+#include "interval_system.h"
 
 namespace banana {
 namespace graph {
@@ -43,7 +44,11 @@ public:
    * Builds a crossing matrix (edge crosses between each pair of vertices)
    * indexed by the vertices in part B.
    * */
-  std::vector<std::vector<int>> buildCrossingMatrix() const;
+  std::vector<std::vector<int>> buildCrossingMatrix() const; 
+
+  /* Get vertices in partitions A and B */
+  std::vector<int> getA() const;
+  std::vector<int> getB() const;
 
 protected:
   std::vector<int> m_partA, m_partB;

--- a/src/bipartite_graph.h
+++ b/src/bipartite_graph.h
@@ -43,7 +43,7 @@ public:
    * Builds a crossing matrix (edge crosses between each pair of vertices)
    * indexed by the vertices in part B.
    * */
-  std::vector<std::vector<int>> buildCrossingMatrix() const; 
+  std::vector<std::vector<int>> buildCrossingMatrix() const;
 
   /* Get vertices in partitions A and B */
   std::vector<int> getA() const;
@@ -56,4 +56,4 @@ protected:
 } // namespace graph
 } // namespace banana
 
-#endif  // __PACE2024__BIPARTITE_GRAPH_H
+#endif // __PACE2024__BIPARTITE_GRAPH_H

--- a/src/bipartite_graph.h
+++ b/src/bipartite_graph.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Top contributors (to current version):
- *   Alan Prado
+ *   Alan Prado, Heitor Leite
  *
  * This file is part of Banana, a one-sided crossing minimization solver.
  *
@@ -56,4 +56,4 @@ protected:
 } // namespace graph
 } // namespace banana
 
-#endif // __PACE2024__BIPARTITE_GRAPH_HPP
+#endif  // __PACE2024__BIPARTITE_GRAPH_H

--- a/src/bipartite_graph.h
+++ b/src/bipartite_graph.h
@@ -17,7 +17,6 @@
 #define __PACE2024__BIPARTITE_GRAPH_H
 
 #include "lgraph.h"
-#include "interval_system.h"
 
 namespace banana {
 namespace graph {

--- a/src/crossing_matrix.cpp
+++ b/src/crossing_matrix.cpp
@@ -57,7 +57,8 @@ CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph) {
    * NOTE: The paper only consider active vertices whose interval that
    * strictly contain (l < x < r) the current vertex, but that seemed to produce
    * wrong results. (l <= x <= r) works, but seems to compute crossing numbers
-   * for some non-orientable pairs too. Further research is needed. */
+   * for some non-orientable pairs too. Instead, we implemented an alternative
+   * similar algorithm. */
   std::unordered_set<int> active;
 
   /* TODO: use vectors */
@@ -67,14 +68,19 @@ CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph) {
   {
     for (int b : graph.neighborhood(a)) d_leq[b]++;
 
-    /* This can possibly be quadratic, we probably want to drop the second if
-     * condition */
+    for (int u : graph.neighborhood(a)) {
+      if (l[u] == a) continue;
+      for (int v : close[a])
+        if (u != v) m_map[{u, v}] += d_less[v];
+    }
+     
+    for (int b : close[a]) active.erase(b);
+    
     for (int u : graph.neighborhood(a))
       for (int v : active)
-        if (u != v && r[v] != l[u]) m_map[{u, v}] += d_less[v];
-     
+        if (u != v) m_map[{u, v}] += d_less[v];
+    
     for (int b : open[a]) active.insert(b);
-    for (int b : close[a]) active.erase(b);
     for (int b : graph.neighborhood(a)) d_less[b]++;
   }
   

--- a/src/crossing_matrix.cpp
+++ b/src/crossing_matrix.cpp
@@ -1,0 +1,106 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Heitor Leite
+ *
+ * This file is part of Banana, a one-sided crossing minimization solver.
+ *
+ * Copyright (c) 2024 by the authors listed in the file AUTHORS in the
+ * top-level source directory and their institutional affiliations. All rights
+ * reserved. See the file LICENSE.md in the top-level source directory for
+ * licensing information.
+ * ****************************************************************************
+ *
+ * Crossing matrix.
+ */
+
+#include "crossing_matrix.h"
+#include "bipartite_graph.h"
+#include <vector>
+#include <unordered_set>
+#include <unordered_map>
+
+namespace banana {
+namespace crossing {
+
+CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph) {
+  /* Computes the naive interval system */
+  std::vector<std::vector<int>> open(graph.countVerticesA()+1);
+  std::vector<std::vector<int>> close(graph.countVerticesA()+1);
+  std::unordered_map<int, int> right;
+
+  for (int v : graph.getB())
+  {
+    int l = -1, r = -1;
+    for (int u : graph.neighborhood(v))
+    {
+      if (l == -1 || u < l) l = u;
+      if (r == -1 || u > r) r = u;
+    }
+    right[v] = r;
+
+    if (l == -1) continue;
+    open[l].push_back(v);
+    close[r].push_back(v);
+  }
+
+  /* NOTE: The paper users a doubly linked list, maybe we should consider that?
+   *
+   * NOTE: The paper only consider active vertices whose interval that
+   * strictly contain (l < x < r) the current vertex, but that seemed to produce
+   * wrong results. (l <= x <= r) works, but seems to compute crossing numbers
+   * for some non-orientable pairs too. Further research is needed. */
+  std::unordered_set<int> active;
+
+  /* First scan trough A: initializes counters for all orientable pairs
+   *
+   * We can probably only do one scan for now, this first one is used only to
+   * limit computation in the decision version of the problem (if a counter is
+   * initialized more than 2k times, the instance is infeasible)
+   */
+  for (int a : graph.getA())
+  {
+    for (int b : open[a]) active.insert(b);
+
+    for (int u : graph.neighborhood(a))
+      for (int v : active)
+        if (u != v) m_map[u][v] = 0;
+    
+    for (int b : close[a]) active.erase(b);
+  }
+
+  std::unordered_map<int, int> d_less, d_leq;
+
+  /* Second scan: computes crossing numbers for orientable pairs */
+  for (int a : graph.getA())
+  {
+    for (int b : graph.neighborhood(a)) d_leq[b]++;
+    for (int b : open[a]) active.insert(b);
+
+    for (int u : graph.neighborhood(a))
+      for (int v : active)
+        if (u != v) m_map[u][v] += d_less[v];
+
+    for (int u : active)
+      for (int v : graph.neighborhood(a))
+      {
+        if (u == v || right[v] != a) continue;
+        m_map[u][v] += graph.degree(v) * (graph.degree(u) - d_leq[u]);
+      }
+
+    for (int b : close[a]) active.erase(b);
+    for (int b : graph.neighborhood(a)) d_less[b]++;
+  }
+}
+
+/* TODO: decide how to handle forced and free pairs */
+int CrossingMatrix::CrossingMatrix::operator()(int u, int v) const
+{
+  /* NOTE: we want .at() here because of const */
+  if (m_map.find(u) == m_map.end()) return -1;
+  auto x = m_map.at(u);
+  if (x.find(v) == x.end()) return -1;
+  return x.at(v);
+};
+
+} // namespace crossing
+} // namespace banana

--- a/src/crossing_matrix.cpp
+++ b/src/crossing_matrix.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>
-#include <iostream>
 
 namespace banana {
 namespace crossing {
@@ -55,8 +54,6 @@ CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph)
       close[r[v]].push_back(v);
     }
   }
-
-  std::cout << std::endl;
 
   /* NOTE: The paper users a doubly linked list, maybe we should consider that?
    *

--- a/src/crossing_matrix.cpp
+++ b/src/crossing_matrix.cpp
@@ -24,11 +24,12 @@
 namespace banana {
 namespace crossing {
 
-CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph) {
+CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph)
+{
   /* Computes the naive interval system */
-  std::vector<std::vector<int>> open(graph.countVerticesA()+1);
-  std::vector<std::vector<int>> close(graph.countVerticesA()+1);
-  std::vector<std::vector<int>> openclose(graph.countVerticesA()+1);
+  std::vector<std::vector<int>> open(graph.countVerticesA() + 1);
+  std::vector<std::vector<int>> close(graph.countVerticesA() + 1);
+  std::vector<std::vector<int>> openclose(graph.countVerticesA() + 1);
 
   std::unordered_map<int, int> l, r;
 
@@ -37,14 +38,19 @@ CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph) {
     l[v] = -1, r[v] = -1;
     for (int u : graph.neighborhood(v))
     {
-      if (l[v] == -1 || u < l[v]) l[v] = u;
-      if (r[v] == -1 || u > r[v]) r[v] = u;
+      if (l[v] == -1 || u < l[v])
+        l[v] = u;
+      if (r[v] == -1 || u > r[v])
+        r[v] = u;
     }
-    
-    if (l[v] == -1) continue;
 
-    if (l[v] == r[v]) openclose[l[v]].push_back(v);
-    else {
+    if (l[v] == -1)
+      continue;
+
+    if (l[v] == r[v])
+      openclose[l[v]].push_back(v);
+    else
+    {
       open[l[v]].push_back(v);
       close[r[v]].push_back(v);
     }
@@ -66,56 +72,72 @@ CrossingMatrix::CrossingMatrix(graph::BipartiteGraph graph) {
 
   for (int a : graph.getA())
   {
-    for (int b : graph.neighborhood(a)) d_leq[b]++;
+    for (int b : graph.neighborhood(a))
+      d_leq[b]++;
 
-    for (int u : graph.neighborhood(a)) {
-      if (l[u] == a) continue;
+    for (int u : graph.neighborhood(a))
+    {
+      if (l[u] == a)
+        continue;
       for (int v : close[a])
-        if (u != v) m_map[{u, v}] += d_less[v];
+        if (u != v)
+          m_map[{u, v}] += d_less[v];
     }
-     
-    for (int b : close[a]) active.erase(b);
-    
+
+    for (int b : close[a])
+      active.erase(b);
+
     for (int u : graph.neighborhood(a))
       for (int v : active)
-        if (u != v) m_map[{u, v}] += d_less[v];
-    
-    for (int b : open[a]) active.insert(b);
-    for (int b : graph.neighborhood(a)) d_less[b]++;
+        if (u != v)
+          m_map[{u, v}] += d_less[v];
+
+    for (int b : open[a])
+      active.insert(b);
+    for (int b : graph.neighborhood(a))
+      d_less[b]++;
   }
-  
-  if (!active.empty()) throw std::runtime_error("active is not empty");
+
+  if (!active.empty())
+    throw std::runtime_error("active is not empty");
   active.clear(), d_leq.clear(), d_less.clear();
 
   for (int a : graph.getA())
   {
-    for (int b : graph.neighborhood(a)) d_leq[b]++; 
-    for (int b : close[a]) active.erase(b);
+    for (int b : graph.neighborhood(a))
+      d_leq[b]++;
+    for (int b : close[a])
+      active.erase(b);
 
-    for (int u : active) {
+    for (int u : active)
+    {
       for (int v : close[a])
         m_map[{u, v}] += graph.degree(v) * (graph.degree(u) - d_leq[u]);
 
       for (int v : openclose[a])
         m_map[{u, v}] += graph.degree(v) * (graph.degree(u) - d_leq[u]);
     }
-    
-    for (int b : open[a]) active.insert(b);
-    for (int b : graph.neighborhood(a)) d_less[b]++;
-  }   
+
+    for (int b : open[a])
+      active.insert(b);
+    for (int b : graph.neighborhood(a))
+      d_less[b]++;
+  }
 }
 
 /* TODO: decide how to handle forced and free pairs */
 int CrossingMatrix::CrossingMatrix::operator()(int u, int v) const
 {
   /* NOTE: we want .at() here because of const */
-  if (m_map.find({u, v}) == m_map.end()) return -1;
+  if (m_map.find({u, v}) == m_map.end())
+    return -1;
   return m_map.at({u, v});
 };
 
-std::vector<std::pair<int, int>> CrossingMatrix::getOrientablePairs() {
+std::vector<std::pair<int, int>> CrossingMatrix::getOrientablePairs()
+{
   std::vector<std::pair<int, int>> res;
-  for (auto[p, c] : m_map)
+  for (auto [p, c] : m_map)
     res.push_back(p);
   return res;
 }

--- a/src/crossing_matrix.h
+++ b/src/crossing_matrix.h
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Top contributors (to current version):
+ *   Heitor Leite
+ *
+ * This file is part of Banana, a one-sided crossing minimization solver.
+ *
+ * Copyright (c) 2024 by the authors listed in the file AUTHORS in the
+ * top-level source directory and their institutional affiliations. All rights
+ * reserved. See the file LICENSE.md in the top-level source directory for
+ * licensing information.
+ * ****************************************************************************
+ *
+ * Crossing matrix.
+ */
+
+#ifndef __PACE2024__CROSSING_MATRIX_H
+#define __PACE2024__CROSSING_MATRIX_H
+
+#include "bipartite_graph.h"
+#include "interval_system.h"
+#include <unordered_map>
+
+namespace banana {
+namespace crossing {
+
+class CrossingMatrix
+{
+public:
+  CrossingMatrix(graph::BipartiteGraph graph);
+  ~CrossingMatrix() = default;
+
+  int operator()(int u, int v) const;
+
+protected:
+  std::unordered_map<int, std::unordered_map<int, int>> m_map;
+};
+
+} // namespace crossing
+} // namespace banana
+
+#endif  // __PACE2024__CROSSING_MATRIX_H

--- a/src/crossing_matrix.h
+++ b/src/crossing_matrix.h
@@ -35,8 +35,10 @@ public:
 protected:
   /* Is this the best way to hash pairs? It works fine assuming size_t is 8
    * bytes and int 4 bytes */
-  struct pair_hash {
-    size_t operator() (const std::pair<int, int>& p) const {
+  struct pair_hash
+  {
+    size_t operator()(const std::pair<int, int> &p) const
+    {
       return ((size_t)p.first << 32) | p.second;
     }
   };
@@ -47,4 +49,4 @@ protected:
 } // namespace crossing
 } // namespace banana
 
-#endif  // __PACE2024__CROSSING_MATRIX_H
+#endif // __PACE2024__CROSSING_MATRIX_H

--- a/src/crossing_matrix.h
+++ b/src/crossing_matrix.h
@@ -18,6 +18,7 @@
 
 #include "bipartite_graph.h"
 #include <unordered_map>
+#include <map>
 
 namespace banana {
 namespace crossing {
@@ -29,9 +30,18 @@ public:
   ~CrossingMatrix() = default;
 
   int operator()(int u, int v) const;
+  std::vector<std::pair<int, int>> getOrientablePairs();
 
 protected:
-  std::unordered_map<int, std::unordered_map<int, int>> m_map;
+  /* Is this the best way to hash pairs? It works fine assuming size_t is 8
+   * bytes and int 4 bytes */
+  struct pair_hash {
+    size_t operator() (const std::pair<int, int>& p) const {
+      return ((size_t)p.first << 32) | p.second;
+    }
+  };
+
+  std::unordered_map<std::pair<int, int>, int, pair_hash> m_map;
 };
 
 } // namespace crossing

--- a/src/crossing_matrix.h
+++ b/src/crossing_matrix.h
@@ -17,7 +17,6 @@
 #define __PACE2024__CROSSING_MATRIX_H
 
 #include "bipartite_graph.h"
-#include "interval_system.h"
 #include <unordered_map>
 
 namespace banana {


### PR DESCRIPTION
Fixes #9.

This PR implements a modified version of [Kobayashi and Tamaki's algorithm](https://link.springer.com/content/pdf/10.1007/s00453-014-9872-x.pdf) for computing crossing numbers for orientable pairs only. Tested against the tiny medium testsets. Example usage:

```cpp
banana::crossing::CrossingMatrix c(graph);

auto p = c.getOrientablePairs();
std::cout << p.size() << " orientable pairs:" << std::endl;
for (auto[i, j] : p)
  std::cout << i+1 << ',' << j+1 << std::endl;

for (int i : graph.getB())
{
  for (int j : graph.getB())
    std::cout << std::setw(2) << c(i, j) << ' ';
  std::cout << std::endl;
}
```

#### Summary of changes:

- Implemented the `CrossingMatrix` class
- Slightly modified `BipartiteGraph`: added `getA()` and `getB()` to be able to get partitions more easily. Not sure if this is the approach we are going for. There was some discussion about relabelling vertices to be 0-indexed on each partition, but I think this is better in some ways. cc @MvKaio